### PR TITLE
Introduction redis for chat

### DIFF
--- a/taskhub/config/environments/.env.redis
+++ b/taskhub/config/environments/.env.redis
@@ -1,0 +1,3 @@
+HOST_REDIS= local de host
+port_REDIS= porta de host
+DECODE_RESPONSES= True 

--- a/taskhub/core/models/contentRepository.py
+++ b/taskhub/core/models/contentRepository.py
@@ -6,6 +6,7 @@ class ContentRepository(Document):
     discussionId = StringField(required=True)
     tag = DictField()
     created_at = DateTimeField(default=datetime.datetime.utcnow)
+    chat_id = StringField()
 
 class Note(ContentRepository):
     title = StringField(max_length=120, required=True)

--- a/taskhub/core/services/chat_redis_control.py
+++ b/taskhub/core/services/chat_redis_control.py
@@ -1,0 +1,17 @@
+from taskhub.infra.database.redis.connect_redis import redis_client
+from datetime import datetime 
+import json
+
+r = redis_client
+
+def save_message(chat_id:str, userId:str, message:str):
+        key = f"chat:{chat_id}"
+        data = {
+                "userId": userId,
+                "timestamp": datetime.utcnow().isoformat(), 
+                "message": message
+        }
+        r.rpush(key, json.dumps(data))
+        r.expire(key, 60 * 60 * 48)
+
+

--- a/taskhub/core/services/chat_redis_control.py
+++ b/taskhub/core/services/chat_redis_control.py
@@ -13,5 +13,11 @@ def save_message(chat_id:str, userId:str, message:str):
         }
         r.rpush(key, json.dumps(data))
         r.expire(key, 60 * 60 * 48)
+        get_chat_messages(chat_id)
 
+def get_chat_messages(chat_id:str):
+        key = f"chat:{chat_id}"
+        raw_messages = r.lrange(key, 0 , -1)
+        return [json.loads(message) for message in raw_messages]
 
+def 

--- a/taskhub/core/services/chat_redis_control.py
+++ b/taskhub/core/services/chat_redis_control.py
@@ -20,4 +20,9 @@ def get_chat_messages(chat_id:str):
         raw_messages = r.lrange(key, 0 , -1)
         return [json.loads(message) for message in raw_messages]
 
-def 
+def delete_chat(chat_id:str) -> bool:
+        key = f"chat:{chat_id}"
+        result = r.delete(key)
+        if(result != 1):
+                raise ValueError("failed delete chat")
+        get_chat_messages(chat_id)

--- a/taskhub/core/services/chat_redis_control.py
+++ b/taskhub/core/services/chat_redis_control.py
@@ -13,7 +13,7 @@ def save_message(chat_id:str, userId:str, message:str):
         }
         r.rpush(key, json.dumps(data))
         r.expire(key, 60 * 60 * 48)
-        get_chat_messages(chat_id)
+        return get_chat_messages(chat_id)
 
 def get_chat_messages(chat_id:str):
         key = f"chat:{chat_id}"
@@ -24,5 +24,5 @@ def delete_chat(chat_id:str) -> bool:
         key = f"chat:{chat_id}"
         result = r.delete(key)
         if(result != 1):
-                raise ValueError("failed delete chat")
-        get_chat_messages(chat_id)
+                raise ValueError("failed delete chat: invalid key or expired chat")
+        return result

--- a/taskhub/infra/database/redis/connect_redis.py
+++ b/taskhub/infra/database/redis/connect_redis.py
@@ -1,0 +1,21 @@
+import environ
+import redis
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+env = environ.Env()
+env.read_env(BASE_DIR / 'taskhub' / 'config' / 'environments' / '.env')  
+
+def redis_connect():
+    host=env('HOST_REDIS')
+    port=env.int('PORT_REDIS')
+    decode=env.bool('DECODE_RESPONSES')
+
+    return redis.Redis(
+        host=host,
+        port=port,
+        decode_responses=decode
+    )
+
+redis_client = redis_connect()


### PR DESCRIPTION
# 🧠 Integração Redis para Chat Temporário

Este módulo implementa a funcionalidade de **chat temporário por repositório**, utilizando **Redis** como armazenamento em memória com tempo de expiração (TTL).

## 📌 Objetivo
Permitir conversas rápidas entre colaboradores (usuários) vinculadas a conteúdos de repositório (`Note`, `Task`, etc.), armazenadas temporariamente por até 48h.

---

## 📦 Estrutura

### 🔧 Arquivo de configuração: `infra/database/redis/connect_redis.py`
- Import Client redis

```python
from taskhub.infra.database.redis.connect_redis import redis_client
```

---

### 💬 Funções de chat 

#### `save_chat_message(chat_id: str, user_id: str, message: str)`
Salva uma nova mensagem no Redis com metadados:

```json
{
  "user_id": "abc123",
  "timestamp": "2025-07-23T14:20:30",
  "message": "Olá, equipe!"
}
```

#### `get_chat_messages(chat_id: str)`
Retorna todas as mensagens de um chat como uma lista de objetos JSON.

#### `chat_id`
Cada conteúdo (`ContentRepository`) deve ter um `chat_id` único persistido no Mongo para referenciar a conversa temporária no Redis.


---

## ✅ Dependências
- `redis-py`: `pip install redis[hiredis]`
- `.env` 